### PR TITLE
Added support for I2C and demo using ssd1327_i2c_ea_w128128

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ message(STATUS "[U8G2] U8G2_LIBRARIES = ${U8G2_LIBRARIES}")
 message(STATUS "[WIRING-PI] WIRINGPI_LIBRARIES = ${WIRINGPI_LIBRARIES}")
 message(STATUS "[WIRING-PI] WIRINGPI_INCLUDE_DIR = ${WIRINGPI_INCLUDE_DIR}")
 
-add_executable(u8g2demo main.h main.cpp ${U8G2_HEADER_FILES} ${U8G2_SRC_FILES} spi.cpp spi.h u8g2_hal_rpi.cpp u8g2_hal_rpi.h)
+add_executable(u8g2demo main.h main.cpp ${U8G2_HEADER_FILES} ${U8G2_SRC_FILES} spi.cpp spi.h u8g2_hal_rpi.cpp u8g2_hal_rpi.h u8g2_hal_rpi_i2c.cpp u8g2_hal_rpi_i2c.h)
 
 include_directories(${LIB_DIR}/bcm2835/src)
 include_directories(${WIRINGPI_INCLUDE_DIR} ${U8G2_INCLUDE_DIR})

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The binary output can be found in the following path:
 # Supported Features
 
 - SPI Hardware/Software implementations
-- I2C (Not yet supported)
+- I2C
 
 
 # Sample Usage

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "u8g2_hal_rpi.h"
+#include "u8g2_hal_rpi_i2c.h"
 
 using namespace std;
 
@@ -12,6 +13,21 @@ u8g2_t u8g2;
 
 static volatile bool complete = false;
 static int forced_exit_attempts = 0;
+
+// for drawBannerText()
+static const char* scroll_text = "UG82 running on Raspberry Pi!";
+static u8g2_uint_t scroll_start_x = 255;
+static u8g2_uint_t scroll_step_x = 5;
+static u8g2_uint_t scroll_y = 32;
+static unsigned int scroll_delay = 500;
+
+// for debug trace
+#define DEBUG_TRACE(x) { \
+    int t0 = millis(); \
+    x \
+    int t1 = millis(); \
+    cout << #x << " takes " << t1 - t0 << " msec" << endl; \
+}
 
 void exitHandler(int s) {
     if (forced_exit_attempts >= 2) {
@@ -49,7 +65,7 @@ void drawU8G2Logo(u8g2_t *u8g2) {
 
 void drawBannerText(u8g2_t *u8g2, uint32_t durationSecs) {
 
-    uint8_t x = 255;
+    u8g2_uint_t x = scroll_start_x;
     uint32_t prevMillis = 0;
 
     //Set Font
@@ -68,18 +84,22 @@ void drawBannerText(u8g2_t *u8g2, uint32_t durationSecs) {
             elapsed++;
         }
 
-        if (x <= 0)
-            x = 255;
         u8g2_ClearBuffer(u8g2);
-        string text = "UG82 running on Raspberry Pi!";
-        u8g2_DrawStr(u8g2, x, 32, text.c_str());
+        u8g2_DrawStr(u8g2, x, scroll_y, scroll_text);
+        // DEBUG_TRACE(
         u8g2_SendBuffer(u8g2);
-        x-=5;
-        delay(500);
+        // )
+        if (x >= scroll_step_x) {
+            x -= scroll_step_x;
+        }
+        else {
+            x = scroll_start_x;
+        }
+        delay(scroll_delay);
     }
 }
 
-int main() {
+int main(int argc, char* argv[]) {
     struct sigaction sigIntHandler{};
     sigIntHandler.sa_handler = exitHandler;
     sigemptyset(&sigIntHandler.sa_mask);
@@ -89,6 +109,9 @@ int main() {
     //Initialize Wiring Pi
     wiringPiSetup();
 
+    if ((argc == 1)
+    ||  (argc > 1 && strcmp(argv[argc-1], "st7920_s_128x64") == 0)) {
+
     //Configure the SPI pins
     u8g2_rpi_hal_t u8g2_rpi_hal = {14 /*CLOCK/EN*/, 12 /*MOSI/RW*/, 10 /*CS/RS*/};
     u8g2_rpi_hal_init(u8g2_rpi_hal);
@@ -97,6 +120,42 @@ int main() {
     //see https://github.com/olikraus/u8g2/wiki/Porting-to-new-MCU-platform#communication-callback-eg-u8x8_byte_hw_i2c
     //ex: u8x8_byte_4wire_sw_spi
     u8g2_Setup_st7920_s_128x64_f(&u8g2, U8G2_R2, cb_byte_spi_hw, cb_gpio_delay_rpi);
+
+    }
+    else if (argc > 1 && strcmp(argv[argc-1], "ssd1327_i2c_ea_w128128") == 0) {
+        // Initialize I2C
+        const u8g2_hal_rpi_i2c_config_t config = {
+            "/dev/i2c-1" // ifname
+            , 0x3c // target_addr
+            , 0 // debug
+            , 0 // verbose
+        };
+        u8g2_hal_rpi_i2c_set_config(config);
+
+        // Setup U8g2 for display "ea_w128128" and controller "ssd1327" via I2C
+        u8g2_Setup_ssd1327_i2c_ea_w128128_f(&u8g2, U8G2_R0, u8g2_hal_rpi_i2c_cb, u8g2_hal_rpi_i2c_cb);
+
+        // for drawBannerText()
+        scroll_text = "Raspberry Pi I2C";
+        scroll_start_x = 128;
+        scroll_step_x = 8;
+        scroll_delay = 100;
+
+        cout << "U8g2 and HAL Configuration" << endl
+             << "  display_type: " << argv[argc-1] << endl
+             << "  interface_type: I2C" << endl
+             << "  interface_name: " << config.ifname << endl
+             << "  target_address: " << config.target_addr << endl
+             << "  debug: " << config.debug << endl
+             << "  verbose: " << config.verbose << endl;
+    }
+    else {
+        cerr << "Usage: " << argv[0] << " [DISPLAY_TYPE]" << endl
+             << "  DISPLAY_TYPE: one of the following names" << endl
+             << "    st7920_s_128x64 (default type)" << endl
+             << "    ssd1327_i2c_ea_w128128" << endl;
+	return 0;
+    }
 
     //Initialize Display
     u8g2_InitDisplay(&u8g2);

--- a/main.cpp
+++ b/main.cpp
@@ -135,6 +135,9 @@ int main(int argc, char* argv[]) {
         // Setup U8g2 for display "ea_w128128" and controller "ssd1327" via I2C
         u8g2_Setup_ssd1327_i2c_ea_w128128_f(&u8g2, U8G2_R0, u8g2_hal_rpi_i2c_cb, u8g2_hal_rpi_i2c_cb);
 
+        // For better U8g2 performance, you can change I2C bus speed to 400 kb/s with the following configuration.
+        // /boot/config.txt: `dtparam=i2c_arm=on,i2c_arm_baudrate=400000`
+
         // for drawBannerText()
         scroll_text = "Raspberry Pi I2C";
         scroll_start_x = 128;

--- a/u8g2_hal_rpi_i2c.cpp
+++ b/u8g2_hal_rpi_i2c.cpp
@@ -1,0 +1,132 @@
+/**
+ *  This file provides implementation for U8g2 HAL implementation for Raspberry Pi I2C.
+ *  @brief U8g2 HAL implementation for Raspberry Pi I2C
+ *  @file
+ *  @author Tomoyuki Nakashima
+*/
+
+// u8g2 + external I/F of this file
+#include "u8g2_hal_rpi_i2c.h"
+
+// std::cout, std::cerr, std::strerror()
+#include <iostream>
+#include <cstring>
+
+// assert()
+#include <cassert>
+
+// open(), close(), write() and ioctl() for I2C deriver
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/i2c-dev.h>
+
+// delay()
+#include <wiringPi.h>
+
+using namespace std;
+
+static u8g2_hal_rpi_i2c_config_t i2c_config;
+
+void u8g2_hal_rpi_i2c_set_config(u8g2_hal_rpi_i2c_config_t config) {
+    assert(config.ifname);
+    assert(config.ifname[0]);
+    assert(config.target_addr >= 0x00);
+    assert(config.target_addr <= 0x7F);
+    i2c_config = config;
+}
+
+uint8_t u8g2_hal_rpi_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
+    static uint8_t send_buf[32]; // u8g2/u8x8 will never send more than 32 bytes between START_TRANSFER and END_TRANSFER
+    static uint8_t send_cnt = 0;
+    static int last_errno = -1;
+    switch (msg) {
+        case U8X8_MSG_BYTE_INIT: { // 20
+            if (i2c_config.debug) cout << "U8X8_MSG_BYTE_INIT" << endl;
+            break;
+        }
+        case U8X8_MSG_BYTE_SEND: { // 23
+            if (i2c_config.verbose) cout << "U8X8_MSG_BYTE_SEND " << int(arg_int) << endl;
+            uint8_t* p = (uint8_t*) arg_ptr;      
+            while (arg_int > 0)
+            {
+	        send_buf[send_cnt++] = *p++;
+	        arg_int--;
+            }  
+            break;
+        }
+        case U8X8_MSG_BYTE_START_TRANSFER: { // 24
+            if (i2c_config.verbose) cout << "U8X8_MSG_BYTE_START_TRANSFER" << endl;
+            send_cnt = 0;
+            break;
+        }
+        case U8X8_MSG_BYTE_END_TRANSFER: { // 25
+            if (i2c_config.verbose) cout << "U8X8_MSG_BYTE_END_TRANSFER " << int(send_cnt) << endl;
+            if (send_cnt <= 0) break;
+            int i2c_fd = open(i2c_config.ifname, O_RDWR);
+            if (i2c_fd < 0) {
+                if (last_errno != errno) {
+                    cerr << "Error: open() failed"
+                         << ", path: " << i2c_config.ifname
+                         << ", error: " << strerror(errno) << endl;
+                    last_errno = errno;
+                }
+                break;
+            }
+            if (ioctl(i2c_fd, I2C_SLAVE, i2c_config.target_addr) < 0) {
+                if (last_errno != errno) {
+                    cerr << "Error: ioctl() failed"
+                         << ", request: I2C_SLAVE"
+                         << ", address: " << int(i2c_config.target_addr)
+                         << ", error: " << strerror(errno) << endl;
+                    last_errno = errno;
+                }
+            }
+            else if (write(i2c_fd, send_buf, send_cnt) < 0) {
+                if (last_errno != errno) {
+                    cerr << "Error: write() failed"
+                         << ", count: " << int(send_cnt)
+                         << ", error: " << strerror(errno) << endl;
+                    last_errno = errno;
+                }
+            }
+            close(i2c_fd);
+            send_cnt = 0;
+            break;
+        }
+        case U8X8_MSG_GPIO_AND_DELAY_INIT: { // 40
+            if (i2c_config.debug) cout << "U8X8_MSG_GPIO_AND_DELAY_INIT" << endl;
+            break;
+        }
+        case U8X8_MSG_DELAY_MILLI: { // 41
+            if (i2c_config.debug) cout << "U8X8_MSG_DELAY_MILLI " << int(arg_int) << endl;
+            delay(arg_int);
+            break;
+        }
+        case U8X8_MSG_DELAY_10MICRO: { // 42
+            if (i2c_config.debug) cout << "U8X8_MSG_DELAY_10MICRO " << int(arg_int) << endl;
+            delayMicroseconds(arg_int * 10);
+            break;
+        }
+        case U8X8_MSG_DELAY_100NANO: { // 43
+            if (i2c_config.debug) cout << "U8X8_MSG_DELAY_100NANO " << int(arg_int) << endl;
+            delayMicroseconds((arg_int + 9) / 10);
+            break;
+        }
+        case U8X8_MSG_DELAY_NANO: { // 44
+            if (i2c_config.debug) cout << "U8X8_MSG_DELAY_NANO " << int(arg_int) << endl;
+            delayMicroseconds(arg_int == 0 ? 0 : 1);
+            break;
+        }
+        case U8X8_MSG_GPIO_RESET: { // 64 + 11
+            if (i2c_config.debug) cout << "U8X8_MSG_GPIO_RESET " << endl;
+            // not supported
+            break;
+        }
+        default: {
+            if (i2c_config.debug) cout << "U8X8_MSG " << int(msg) << endl;
+            return 0;
+        }
+    }
+    return 1;
+}

--- a/u8g2_hal_rpi_i2c.cpp
+++ b/u8g2_hal_rpi_i2c.cpp
@@ -3,7 +3,7 @@
  *  @brief U8g2 HAL implementation for Raspberry Pi I2C
  *  @file
  *  @author Tomoyuki Nakashima
-*/
+ */
 
 // u8g2 + external I/F of this file
 #include "u8g2_hal_rpi_i2c.h"

--- a/u8g2_hal_rpi_i2c.h
+++ b/u8g2_hal_rpi_i2c.h
@@ -1,0 +1,38 @@
+/**
+ *  This file provides inerfaces for U8g2 HAL implementation for Raspberry Pi I2C.
+ *  @brief U8g2 HAL implementation for Raspberry Pi I2C
+ *  @file
+ *  @author Tomoyuki Nakashima
+*/
+
+#ifndef U8G2DEMO_U8G2_HAL_RPI_I2C_H
+#define U8G2DEMO_U8G2_HAL_RPI_I2C_H
+
+// u8g2
+#include <u8g2.h>
+
+/**
+ *  The struct provides I2C Configuration Parameters.
+ *  @brief I2C Configuration Parameters
+ */
+struct u8g2_hal_rpi_i2c_config_t {
+    const char* ifname; ///< I2C interface name, e.g., "/dev/i2c-1"
+    int target_addr; ///< I2C slave address for the target device
+    int debug; ///< 1 if debug output is required
+    int verbose; ///< 1 if verbose output is required
+};
+
+/**
+ *  Set I2C Configuration.
+ *  @brief Set I2C Configuration
+ *  @param param I2C Configuration
+ */
+void u8g2_hal_rpi_i2c_set_config(u8g2_hal_rpi_i2c_config_t param);
+
+/**
+ *  The function provides I2C Callback, conforms to `u8x8_msg_cb`, for both U8g2's `byte_cb` and `gpio_and_delay_cb`.
+ *  @brief I2C Callback
+ */
+uint8_t u8g2_hal_rpi_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+
+#endif // U8G2DEMO_U8G2_HAL_RPI_I2C_H

--- a/u8g2_hal_rpi_i2c.h
+++ b/u8g2_hal_rpi_i2c.h
@@ -30,7 +30,7 @@ struct u8g2_hal_rpi_i2c_config_t {
 void u8g2_hal_rpi_i2c_set_config(u8g2_hal_rpi_i2c_config_t param);
 
 /**
- *  The function provides I2C Callback, conforms to `u8x8_msg_cb`, for both U8g2's `byte_cb` and `gpio_and_delay_cb`.
+ *  The function provides I2C Callback that conforms to U8g2's `u8x8_msg_cb` and applicable to both `byte_cb` and `gpio_and_delay_cb`.
  *  @brief I2C Callback
  */
 uint8_t u8g2_hal_rpi_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);

--- a/u8g2_hal_rpi_i2c.h
+++ b/u8g2_hal_rpi_i2c.h
@@ -3,7 +3,9 @@
  *  @brief U8g2 HAL implementation for Raspberry Pi I2C
  *  @file
  *  @author Tomoyuki Nakashima
-*/
+ *  @remark For better U8g2 performance, you can change I2C bus speed to 400 kb/s with the following configuration. <br>
+ *  /boot/config.txt: `dtparam=i2c_arm=on,i2c_arm_baudrate=400000`
+ */
 
 #ifndef U8G2DEMO_U8G2_HAL_RPI_I2C_H
 #define U8G2DEMO_U8G2_HAL_RPI_I2C_H


### PR DESCRIPTION
@ribasco 
I added support for I2C to your u8g2-rpi-demo. Please review it.
I tested it with Zio Qwiic OLED Display and added demo for the display using ssd1327_i2c_ea_w128128.
I also updated main.cpp to make drawBannerText work with the display.